### PR TITLE
Fix wrong behaviour in downloadObjectToFile method

### DIFF
--- a/src/Oktawave/OCS/OCSClient.php
+++ b/src/Oktawave/OCS/OCSClient.php
@@ -404,9 +404,10 @@ class Oktawave_OCS_OCSClient
     {
         $this->isAuthenticated();
 
-        if (!file_exists($destinationPath)) {
+        if (!file_exists(dirname($destinationPath))) {
             mkdir(dirname($destinationPath), 0777, true);
         }
+
         $file = fopen($destinationPath, "w+");
 
         $ret = $this->createCurl($this->bucket . '/' . $path, self::METHOD_GET, array('file' => $file));


### PR DESCRIPTION
Currently, if we have created directory with different files and just want to download another file, we get exception that directory is already created.